### PR TITLE
Detects remote url from local git repo.

### DIFF
--- a/src/GitLink/Extensions/LibGitExtensions.cs
+++ b/src/GitLink/Extensions/LibGitExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace GitLink
+{
+    using System;
+    using LibGit2Sharp;
+
+    public static class LibGitExtensions
+    {
+        public static bool IsDetachedHead(this Branch branch)
+        {
+            return branch.CanonicalName.Equals("(no branch)", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/GitLink/Git/RepositoryLoader.cs
+++ b/src/GitLink/Git/RepositoryLoader.cs
@@ -1,0 +1,31 @@
+﻿namespace GitLink.Git
+{
+    using System;
+    using LibGit2Sharp;
+
+    public class RepositoryLoader
+    {
+        public static Repository GetRepo(string gitDirectory)
+        {
+            try
+            {
+                var repository = new Repository(gitDirectory);
+
+                var branch = repository.Head;
+                if (branch.Tip == null)
+                {
+                    throw new Exception("No Tip found. Has repo been initialized?");
+                }
+                return repository;
+            }
+            catch (Exception exception)
+            {
+                if (exception.Message.Contains("LibGit2Sharp.Core.NativeMethods") || exception.Message.Contains("FilePathMarshaler"))
+                {
+                    throw new Exception("Restart of the process may be required to load an updated version of LibGit2Sharp.");
+                }
+                throw;
+            }
+        }
+    }
+}

--- a/src/GitLink/GitLink.csproj
+++ b/src/GitLink/GitLink.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Authentication.cs" />
     <Compile Include="Extensions\ContextExtensions.cs" />
     <Compile Include="Extensions\IntExtensions.cs" />
+    <Compile Include="Extensions\LibGitExtensions.cs" />
     <Compile Include="Extensions\PdbExtensions.cs" />
     <Compile Include="Extensions\ProjectExtensions.cs" />
     <Compile Include="Extensions\ProjectItemExtensions.cs" />
@@ -88,6 +89,7 @@
     <Compile Include="Git\GitDirFinder.cs" />
     <Compile Include="Git\GitPreparer.cs" />
     <Compile Include="Git\Interfaces\IRepositoryPreparer.cs" />
+    <Compile Include="Git\RepositoryLoader.cs" />
     <Compile Include="Helpers\DeleteHelper.cs" />
     <Compile Include="Helpers\GitHelper.cs" />
     <Compile Include="Helpers\PdbStrHelper.cs" />


### PR DESCRIPTION
PR for #43 

If the TargetUrl is not set then the new code determines if the solution is in a local git repository. 
If so it uses the head for the SHA, and the current branch's remote for the TargetUrl.
If the current branch is detached, it looks for a branch with the current SHA as a commit, and uses that branches remote instead.
If no branches have a remote, then it doesn't set the TargetUrl and the application fails as per normal.
